### PR TITLE
dispatch: Fix initial alerts not honoring group_wait

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -91,7 +91,8 @@ type Dispatcher struct {
 	ctx    context.Context
 	cancel func()
 
-	logger log.Logger
+	logger    log.Logger
+	startTime time.Time
 }
 
 // Limits describes limits used by Dispatcher.
@@ -126,6 +127,7 @@ func NewDispatcher(
 		logger:  log.With(l, "component", "dispatcher"),
 		metrics: m,
 		limits:  lim,
+		startTime: time.Now(),
 	}
 	return disp
 }
@@ -331,7 +333,7 @@ func (d *Dispatcher) processAlert(alert *types.Alert, route *Route) {
 		return
 	}
 
-	ag = newAggrGroup(d.ctx, groupLabels, route, d.timeout, d.logger)
+	ag = newAggrGroup(d.ctx, groupLabels, route, d.timeout, d.logger, d.startTime)
 	routeGroups[fp] = ag
 	d.aggrGroupsNum++
 	d.metrics.aggrGroups.Inc()
@@ -386,20 +388,22 @@ type aggrGroup struct {
 
 	mtx        sync.RWMutex
 	hasFlushed bool
+	startTime  time.Time
 }
 
 // newAggrGroup returns a new aggregation group.
-func newAggrGroup(ctx context.Context, labels model.LabelSet, r *Route, to func(time.Duration) time.Duration, logger log.Logger) *aggrGroup {
+func newAggrGroup(ctx context.Context, labels model.LabelSet, r *Route, to func(time.Duration) time.Duration, logger log.Logger, startTime time.Time) *aggrGroup {
 	if to == nil {
 		to = func(d time.Duration) time.Duration { return d }
 	}
 	ag := &aggrGroup{
-		labels:   labels,
-		routeKey: r.Key(),
-		opts:     &r.RouteOpts,
-		timeout:  to,
-		alerts:   store.NewAlerts(),
-		done:     make(chan struct{}),
+		labels:    labels,
+		routeKey:  r.Key(),
+		opts:      &r.RouteOpts,
+		timeout:   to,
+		alerts:    store.NewAlerts(),
+		done:      make(chan struct{}),
+		startTime: startTime,
 	}
 	ag.ctx, ag.cancel = context.WithCancel(ctx)
 
@@ -484,7 +488,8 @@ func (ag *aggrGroup) insert(alert *types.Alert) {
 	// alert is already over.
 	ag.mtx.Lock()
 	defer ag.mtx.Unlock()
-	if !ag.hasFlushed && alert.StartsAt.Add(ag.opts.GroupWait).Before(time.Now()) {
+	now := time.Now()
+	if !ag.hasFlushed && alert.StartsAt.Add(ag.opts.GroupWait).Before(now) && ag.startTime.Add(ag.opts.GroupWait).Before(now) {
 		ag.next.Reset(0)
 	}
 }

--- a/test/with_api_v1/acceptance/send_test.go
+++ b/test/with_api_v1/acceptance/send_test.go
@@ -432,9 +432,8 @@ receivers:
 	am.Push(At(4), Alert("alertname", "test2"))
 
 	co.Want(Between(2, 2.5), Alert("alertname", "test1").Active(1))
-	// Timers are reset on reload regardless, so we count the 6 second group
-	// interval from 3 onwards.
-	co.Want(Between(9, 9.5),
+
+	co.Want(Between(4, 4.5),
 		Alert("alertname", "test1").Active(1),
 		Alert("alertname", "test2").Active(4),
 	)

--- a/test/with_api_v2/acceptance/send_test.go
+++ b/test/with_api_v2/acceptance/send_test.go
@@ -453,9 +453,8 @@ receivers:
 	amc.Push(At(4), Alert("alertname", "test2"))
 
 	co.Want(Between(2, 2.5), Alert("alertname", "test1").Active(1))
-	// Timers are reset on reload regardless, so we count the 6 second group
-	// interval from 3 onwards.
-	co.Want(Between(9, 9.5),
+
+	co.Want(Between(4, 4.5),
 		Alert("alertname", "test1").Active(1),
 		Alert("alertname", "test2").Active(4),
 	)


### PR DESCRIPTION
At initial startup of Alertmanager, old alerts will be sent to the receivers immediately as the start time for those alerts could be several days old in some cases (and in either way much older than the group_wait time)

This is problematic for alerts that are supposed to be inhibited. If the old inhibited alert gets processed before the alert that is supposed to inhibit it, it will get sent to the receiver and cause unwanted noise.

One approach to combat this is to always wait at least the group_wait duration for a new alert group, even if the alert is very old. This should make things a bit more stable as it gives all alerts a fighting chance to come in before we send out notifications