### PR TITLE
dispatch: Fix initial alerts not honoring group_wait

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -742,6 +742,7 @@ type Route struct {
 	GroupWait      *model.Duration `yaml:"group_wait,omitempty" json:"group_wait,omitempty"`
 	GroupInterval  *model.Duration `yaml:"group_interval,omitempty" json:"group_interval,omitempty"`
 	RepeatInterval *model.Duration `yaml:"repeat_interval,omitempty" json:"repeat_interval,omitempty"`
+	WaitOnStartup bool `yaml:"wait_on_startup" json:"wait_on_startup,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Route.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -857,6 +857,7 @@ receivers:
 	}
 }
 
+
 func TestEmptyFieldsAndRegex(t *testing.T) {
 	boolFoo := true
 	var regexpFoo = Regexp{
@@ -986,6 +987,17 @@ func TestGroupByAll(t *testing.T) {
 
 	if !c.Route.GroupByAll {
 		t.Errorf("Invalid group by all param: expected to by true")
+	}
+}
+
+func TestWaitOnStartup(t *testing.T) {
+	c, err := LoadFile("testdata/conf.wait-on-startup.yml")
+	if err != nil {
+		t.Fatalf("Error parsing %s: %s", "testdata/conf.wait-on-startup.yml", err)
+	}
+
+	if !c.Route.WaitOnStartup {
+		t.Errorf("Invalid wait on startup param: expected to be true")
 	}
 }
 

--- a/config/testdata/conf.wait-on-startup.yml
+++ b/config/testdata/conf.wait-on-startup.yml
@@ -1,0 +1,8 @@
+route:
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 3h
+  receiver: team-X
+  wait_on_startup: True
+receivers:
+  - name: 'team-X'

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -91,7 +91,8 @@ type Dispatcher struct {
 	ctx    context.Context
 	cancel func()
 
-	logger log.Logger
+	logger    log.Logger
+	startTime time.Time
 }
 
 // Limits describes limits used by Dispatcher.
@@ -126,6 +127,7 @@ func NewDispatcher(
 		logger:  log.With(l, "component", "dispatcher"),
 		metrics: m,
 		limits:  lim,
+		startTime: time.Now(),
 	}
 	return disp
 }
@@ -331,7 +333,7 @@ func (d *Dispatcher) processAlert(alert *types.Alert, route *Route) {
 		return
 	}
 
-	ag = newAggrGroup(d.ctx, groupLabels, route, d.timeout, d.logger)
+	ag = newAggrGroup(d.ctx, groupLabels, route, d.timeout, d.logger, d.startTime)
 	routeGroups[fp] = ag
 	d.aggrGroupsNum++
 	d.metrics.aggrGroups.Inc()
@@ -386,20 +388,22 @@ type aggrGroup struct {
 
 	mtx        sync.RWMutex
 	hasFlushed bool
+	startTime  time.Time
 }
 
 // newAggrGroup returns a new aggregation group.
-func newAggrGroup(ctx context.Context, labels model.LabelSet, r *Route, to func(time.Duration) time.Duration, logger log.Logger) *aggrGroup {
+func newAggrGroup(ctx context.Context, labels model.LabelSet, r *Route, to func(time.Duration) time.Duration, logger log.Logger, startTime time.Time) *aggrGroup {
 	if to == nil {
 		to = func(d time.Duration) time.Duration { return d }
 	}
 	ag := &aggrGroup{
-		labels:   labels,
-		routeKey: r.Key(),
-		opts:     &r.RouteOpts,
-		timeout:  to,
-		alerts:   store.NewAlerts(),
-		done:     make(chan struct{}),
+		labels:    labels,
+		routeKey:  r.Key(),
+		opts:      &r.RouteOpts,
+		timeout:   to,
+		alerts:    store.NewAlerts(),
+		done:      make(chan struct{}),
+		startTime: startTime,
 	}
 	ag.ctx, ag.cancel = context.WithCancel(ctx)
 
@@ -484,7 +488,8 @@ func (ag *aggrGroup) insert(alert *types.Alert) {
 	// alert is already over.
 	ag.mtx.Lock()
 	defer ag.mtx.Unlock()
-	if !ag.hasFlushed && alert.StartsAt.Add(ag.opts.GroupWait).Before(time.Now()) {
+	now := time.Now()
+	if !ag.hasFlushed && alert.StartsAt.Add(ag.opts.GroupWait).Before(now) && (!ag.opts.WaitOnStartup || ag.startTime.Add(ag.opts.GroupWait).Before(now)) {
 		ag.next.Reset(0)
 	}
 }

--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -35,6 +35,7 @@ var DefaultRouteOpts = RouteOpts{
 	GroupBy:           map[model.LabelName]struct{}{},
 	GroupByAll:        false,
 	MuteTimeIntervals: []string{},
+	WaitOnStartup: false,
 }
 
 // A Route is a node that contains definitions of how to handle alerts.
@@ -88,6 +89,7 @@ func NewRoute(cr *config.Route, parent *Route) *Route {
 	if cr.RepeatInterval != nil {
 		opts.RepeatInterval = time.Duration(*cr.RepeatInterval)
 	}
+	opts.WaitOnStartup = cr.WaitOnStartup
 
 	// Build matchers.
 	var matchers labels.Matchers
@@ -214,6 +216,9 @@ type RouteOpts struct {
 
 	// A list of time intervals for which the route is active.
 	ActiveTimeIntervals []string
+
+	// Honor the group_wait on initial startup even if incoming alerts are old
+	WaitOnStartup bool
 }
 
 func (ro *RouteOpts) String() string {
@@ -234,12 +239,14 @@ func (ro *RouteOpts) MarshalJSON() ([]byte, error) {
 		GroupWait      time.Duration    `json:"groupWait"`
 		GroupInterval  time.Duration    `json:"groupInterval"`
 		RepeatInterval time.Duration    `json:"repeatInterval"`
+		WaitOnStartup bool `json:"waitOnStartup"`
 	}{
 		Receiver:       ro.Receiver,
 		GroupByAll:     ro.GroupByAll,
 		GroupWait:      ro.GroupWait,
 		GroupInterval:  ro.GroupInterval,
 		RepeatInterval: ro.RepeatInterval,
+		WaitOnStartup: ro.WaitOnStartup,
 	}
 	for ln := range ro.GroupBy {
 		v.GroupBy = append(v.GroupBy, ln)


### PR DESCRIPTION
At initial startup of Alertmanager, old alerts will be sent to the receivers immediately as the start time for those alerts could be several days old in some cases (and in either way much older than the group_wait time)

This is problematic for alerts that are supposed to be inhibited. If the old inhibited alert gets processed before the alert that is supposed to inhibit it, it will get sent to the receiver and cause unwanted noise.

One approach to combat this is to always wait at least the group_wait duration for a new alert group, even if the alert is very old. This should make things a bit more stable as it gives all alerts a fighting chance to come in before we send out notifications

Signed-off-by: Alexander Rickardsson <alxric@aiven.io>